### PR TITLE
Fix end of event collecting

### DIFF
--- a/eventcollector/cf_audit_event_collector.go
+++ b/eventcollector/cf_audit_event_collector.go
@@ -89,12 +89,13 @@ func (c *CfAuditEventCollector) collect(ctx context.Context) (int, error) {
 	go c.fetcher.FetchEvents(ctx, pullEventsSince, eventsChan, errChan)
 
 	eventsCount := 0
+chanloop:
 	for {
 		select {
 		case events, stillOpen := <-eventsChan:
 			if !stillOpen {
 				c.logger.Info("collect.eventschan-closed")
-				break
+				break chanloop
 			}
 			eventsCount += len(events)
 			err := c.store.StoreCfAuditEvents(events)
@@ -106,7 +107,7 @@ func (c *CfAuditEventCollector) collect(ctx context.Context) (int, error) {
 		case err, stillOpen := <-errChan:
 			if !stillOpen {
 				c.logger.Info("collect.errchan-closed")
-				break
+				break chanloop
 			}
 			return eventsCount, err
 		}


### PR DESCRIPTION
What
----

This commit fixes a bug that caused us not to fetch more events after startup. It would get stuck when finishing the first collection.

It turns out that `break` is used to exit `select` statements, not just loops. This commit fixes things.

How to review
-----

Code review.

I note this reinforces the importance of https://github.com/alphagov/paas-auditor/issues/3 😞 

Who can review
-----

Not @46bit. Perhaps @AP-Hunt?