### PR TITLE
[#179252161] bump golang to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Golang application that scrapes Cloud Controller's `/v2/events` endpoint for A
 
 You will need:
 
-* `Go v1.13+`
+* `Go v1.16`
 
 To build the application run the default make target:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-auditor
 
-go 1.15
+go 1.16
 
 require (
 	code.cloudfoundry.org/lager v0.0.0-20180322215153-25ee72f227fe

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ applications:
       - auditor-db
 
     env:
-      GOVERSION: go1.15
+      GOVERSION: go1.16
       GOPACKAGENAME: github.com/alphagov/paas-auditor
 
       CF_API_ADDRESS: ((cf_api_address))


### PR DESCRIPTION
What
----

Bump the required version of golang in the module and cf manifest to 1.16, because we're about to roll out a buildpack which removes 1.15.

How to review
-----

Set a dev pipeline's `paas-auditor` resource's `branch` to this one?

Who can review
-----

Human engineers.
