### PR TITLE
Update manifest to golang 1.17

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ applications:
       - auditor-db
 
     env:
-      GOVERSION: go1.16
+      GOVERSION: go1.17
       GOPACKAGENAME: github.com/alphagov/paas-auditor
 
       CF_API_ADDRESS: ((cf_api_address))


### PR DESCRIPTION


What
----

Managed to overlook the manifest when bumping golang for buildpack upgrade.

How to review
-----

- Chcek tests pass

Who can review
-----

not @schmie 
