### PR TITLE
Update to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-auditor
 
-go 1.20
+go 1.21
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ applications:
       - auditor-db
 
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-auditor
 
       CF_API_ADDRESS: ((cf_api_address))


### PR DESCRIPTION
## What

Use go v1.21

## Why

A recent go buildpack update is dropping support for go 1.20, so updating to 1.21 will let us update this buildpack

## How to review

Ensure that paas-auditor deploys okay to a dev environment and passes tests

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨

