### PR TITLE
Doubling memory resources for paas-auditor-collector

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,8 @@
 ---
 applications:
   - name: paas-auditor
-    memory: 1G
-    disk_quota: 100M
+    memory: 2G
+    disk_quota: 200M
     stack: cflinuxfs3
     instances: 1
     buildpack: go_buildpack


### PR DESCRIPTION
What

Increase the memory and disk_quota to allow the collector to store more audit events

How to review

Check if paas-auditor-collector stops crashing
https://admin.cloud.service.gov.uk/organisations/59e8304f-149a-4bab-84cc-486d936994c3/spaces/a3413ac4-3323-4801-8643-e58dab67fc6d/applications/79fe040a-0609-4ada-b5bb-7a4d98655d7a/events

Who can review

Anyone
