### PR TITLE
Update go.mod and manifests to go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-auditor
 
-go 1.23
+go 1.22
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-auditor
 
-go 1.21
+go 1.23
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ applications:
       - auditor-db
 
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-auditor
 
       CF_API_ADDRESS: ((cf_api_address))

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ applications:
       - auditor-db
 
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-auditor
 
       CF_API_ADDRESS: ((cf_api_address))


### PR DESCRIPTION
What
----
Update mod and manifests to go 1.22
> Initially intended to upgrade go to 1.23, but reverted to 1.22 due to current buildpack compatibility. Buildpack doesn't yet support 1.23.

How to review
-----
Tests and code review

Who can review
-----
PaaS team members
